### PR TITLE
修复了celery异步任务处理报错的问题

### DIFF
--- a/apps/gc_dt/tasks.py
+++ b/apps/gc_dt/tasks.py
@@ -163,5 +163,14 @@ def process_gc_files(self, file_contents_list, user_id, process_id):
         }
         
     except Exception as e:
-        self.update_state(state='FAILURE', meta={'error': str(e)})
+        # 保存原始异常的类型和消息
+        original_exc_type = type(e).__name__
+        error_message = str(e)
+
+        self.update_state(state='FAILURE', meta={
+            'error': error_message,
+            'exc_type': original_exc_type,
+            'exc_message': error_message
+        })
+        # 直接重新抛出原始异常
         raise

--- a/apps/gcms_dt/tasks.py
+++ b/apps/gcms_dt/tasks.py
@@ -246,7 +246,16 @@ def process_gcms_shimazu_files(self, file_contents_list, user_id, process_id, fl
         }
 
     except Exception as e:
-        self.update_state(state='FAILURE', meta={'error': str(e)})
+        # 保存原始异常的类型和消息
+        original_exc_type = type(e).__name__
+        error_message = str(e)
+
+        self.update_state(state='FAILURE', meta={
+            'error': error_message,
+            'exc_type': original_exc_type,
+            'exc_message': error_message
+        })
+        # 直接重新抛出原始异常
         raise
 
 @shared_task(bind=True)
@@ -507,6 +516,15 @@ def process_gcms_thermo_file(self, file_contents_list, user_id, process_id, floa
         }
 
     except Exception as e:
-        self.update_state(state='FAILURE', meta={'error': str(e)})
+        # 保存原始异常的类型和消息
+        original_exc_type = type(e).__name__
+        error_message = str(e)
+
+        self.update_state(state='FAILURE', meta={
+            'error': error_message,
+            'exc_type': original_exc_type,
+            'exc_message': error_message
+        })
+        # 直接重新抛出原始异常
         raise
 

--- a/apps/lc_dt/tasks.py
+++ b/apps/lc_dt/tasks.py
@@ -244,7 +244,16 @@ def process_lc_shimazu_files(self, file_contents_list, user_id, process_id, floa
         }
 
     except Exception as e:
-        self.update_state(state='FAILURE', meta={'error': str(e)})
+        # 保存原始异常的类型和消息
+        original_exc_type = type(e).__name__
+        error_message = str(e)
+        
+        self.update_state(state='FAILURE', meta={
+            'error': error_message,
+            'exc_type': original_exc_type,
+            'exc_message': error_message
+        })
+        # 直接重新抛出原始异常
         raise
 
 
@@ -329,10 +338,10 @@ def process_lc_agilent_files(self, file_contents_list, user_id, process_id, floa
             self.update_state(
                 state='PROGRESS',
                 meta={
-                    'current': index,  # 当前处理文件索引
-                    'total_files': total_files,  # 总文件数
-                    'file_name': file_name,  # 当前处理文件名
-                    'status': file_result["status"]  # 当前处理文件状态
+                    'current': index,                   # 当前处理文件索引
+                    'total_files': total_files,         # 总文件数
+                    'file_name': file_name,             # 当前处理文件名
+                    'status': file_result["status"]     # 当前处理文件状态
                 }
             )
             # ↑ 进度信息存入Redis，作为Result Backend的缓存
@@ -445,5 +454,14 @@ def process_lc_agilent_files(self, file_contents_list, user_id, process_id, floa
         }
 
     except Exception as e:
-        self.update_state(state='FAILURE', meta={'error': str(e)})
+        # 保存原始异常的类型和消息
+        original_exc_type = type(e).__name__
+        error_message = str(e)
+        
+        self.update_state(state='FAILURE', meta={
+            'error': error_message,
+            'exc_type': original_exc_type,
+            'exc_message': error_message
+        })
+        # 直接重新抛出原始异常
         raise

--- a/apps/lcms_dt/tasks.py
+++ b/apps/lcms_dt/tasks.py
@@ -145,7 +145,16 @@ def process_lcms_ab_files(self, file_contents_list, user_id, process_id):
         }
 
     except Exception as e:
-        self.update_state(state='FAILURE', meta={'error': str(e)})
+        # 保存原始异常的类型和消息
+        original_exc_type = type(e).__name__
+        error_message = str(e)
+
+        self.update_state(state='FAILURE', meta={
+            'error': error_message,
+            'exc_type': original_exc_type,
+            'exc_message': error_message
+        })
+        # 直接重新抛出原始异常
         raise
 
 
@@ -299,5 +308,14 @@ def process_lcms_agilent_files(self, file_contents_list, user_id, process_id):
         }
 
     except Exception as e:
-        self.update_state(state='FAILURE', meta={'error': str(e)})
+        # 保存原始异常的类型和消息
+        original_exc_type = type(e).__name__
+        error_message = str(e)
+
+        self.update_state(state='FAILURE', meta={
+            'error': error_message,
+            'exc_type': original_exc_type,
+            'exc_message': error_message
+        })
+        # 直接重新抛出原始异常
         raise


### PR DESCRIPTION
## Celery 任务结果处理机制

- 当任务正常完成时，返回值会被序列化并存储在 Redis 中
- 当任务抛出异常时，Celery 会尝试序列化异常信息
- 但是某些异常可能无法被正确序列化（比如缺少异常类型信息）

## tasks.py中异常处理的方式误区

```python
# 方式1：直接抛出异常
except Exception as e:
    self.update_state(state='FAILURE', meta={'error': str(e)})
    raise  # 这里可能导致序列化问题，从而使得Celery 工作进程崩溃

# 方式2：直接抛出异常，但保存完整的异常信息
except Exception as e:
    # 保存原始异常的类型和消息
    original_exc_type = type(e).__name__
    error_message = str(e)
    
    self.update_state(state='FAILURE', meta={
        'error': error_message,
        'exc_type': original_exc_type,
        'exc_message': error_message
    })
    raise
```

## 为什么需要方式2？

1. Celery 可以正确序列化原始异常
2. 保留了完整的异常类型信息
3. 不会丢失异常的上下文和堆栈跟踪
4. 状态查询视图可以获取到准确的错误信息

## 为什么不能直接返回标准的错误响应结构？

Celery 通过任务的返回方式来判断任务是成功还是失败：

- 如果使用 raise：Celery 将任务标记为 FAILURE 状态
- 如果正常 return：Celery 将任务标记为 SUCCESS 状态
